### PR TITLE
Regeln geändert um die Dot-Notation verwenden zu können.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/validation": "5.7",
+        "illuminate/validation": "~5.7",
         "illuminate/container": "v5.7.0",
         "illuminate/support": ">=4.0.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/container": ">=4.0.0",
-        "illuminate/support": ">=4.0.0",
-        "illuminate/validation": "^5.8@dev"
+        "illuminate/validation": "5.7",
+        "illuminate/container": "v5.7.0",
+        "illuminate/support": ">=4.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.0.*"

--- a/composer.json
+++ b/composer.json
@@ -1,17 +1,17 @@
-
 {
     "name": "daylerees/sanitizer",
     "license": "MIT",
     "authors": [
         {
-            "name": "Dayle Rees",
+            "name": "Dayle Rees + smake",
             "email": "me@daylerees.com"
         }
     ],
     "require": {
         "php": ">=5.3.0",
         "illuminate/container": ">=4.0.0",
-        "illuminate/support": ">=4.0.0"
+        "illuminate/support": ">=4.0.0",
+        "illuminate/validation": "^5.8@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "4.0.*"

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -4,6 +4,7 @@ namespace Rees\Sanitizer;
 
 use Closure;
 use Illuminate\Container\Container;
+use Illimoinate\Validation\ValidationRuleParser;
 
 class Sanitizer
 {
@@ -64,21 +65,11 @@ class Sanitizer
             // Process global sanitizers.
             $this->runGlobalSanitizers($rules, $data);
 
-            $generatedRules = [];
-            $availableRules = array_keys(array_dot($data));
+            $parser = new ValidationRuleParser(parent::validationData());
 
-            //Check for dotted rules
-            array_walk($availableRules,
-                function($item) use (&$generatedRules, $rules) {
-                    $dotRule = preg_replace('/[.]\d+[.]/m', ".*.", $item);
+            $availableRules = $parser->explode($this->rules())->rules;
 
-                    if(array_has($rules, $dotRule)) {
-                        $generatedRules[$item] = $rules[$dotRule];
-                    }
-                }
-            );
-
-            foreach ($generatedRules as $field => $ruleset) {
+            foreach ($availableRules as $field => $ruleset) {
 
                 // Execute sanitizers over a specific field.
                 $this->sanitizeField($data, $field, $ruleset);

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -61,18 +61,29 @@ class Sanitizer
      */
     public function sanitize($rules, &$data)
     {
-        // Process global sanitizers.
-        $this->runGlobalSanitizers($rules, $data);
+            // Process global sanitizers.
+            $this->runGlobalSanitizers($rules, $data);
 
-        $availableRules = array_only($rules, array_keys(array_dot($data)));
+            $generatedRules = [];
+            $availableRules = array_keys(array_dot($data));
 
-        // Iterate rules to be applied.
-        foreach ($availableRules as $field => $ruleset) {
+            //Check for dotted rules
+            array_walk($availableRules,
+                function($item) use (&$generatedRules, $rules) {
+                    $dotRule = preg_replace('/[.]\d+[.]/m', ".*.", $item);
 
-            // Execute sanitizers over a specific field.
-            $this->sanitizeField($data, $field, $ruleset);
-        }
-        return $data;
+                    if(array_has($rules, $dotRule)) {
+                        $generatedRules[$item] = $rules[$dotRule];
+                    }
+                }
+            );
+
+            foreach ($generatedRules as $field => $ruleset) {
+
+                // Execute sanitizers over a specific field.
+                $this->sanitizeField($data, $field, $ruleset);
+            }
+            return $data;
     }
 
     /**


### PR DESCRIPTION
Issue https://github.com/smakecloud/smake/issues/4062.

Muss vor dem dazugehörigen Pull-Request in das Smake-Projekt integriert werden.

Der Pull Request kommt noch.

Die Sanitizerfunktion wurde geändert, damit auch Regel on dot-notation verwendet werden können. 

z.B. 

``````
public function sanitizers()
    {
        return [
            'base_price.price' => 'float',
            'base_price.cost_price' => 'float',
            'scaled_prices.*.price' => 'float',
            'scaled_prices.*.cost_price' => 'float',
            'scaled_prices.*.calculate_from' => 'float',
        ];
    }
